### PR TITLE
[feat] API 문서 자동화를 위한 Swagger API 셋팅 및 AuthController 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/
 !**/src/test/**/build/
 mysql-data/
 
+.github/*
+.DS_Store
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 //	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	// Cache - Redis
 //	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
@@ -42,6 +43,7 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	// OAuth2.0
 //	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 	// Lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -53,6 +55,9 @@ dependencies {
 	// JUnit
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/grimeet/grimeet/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/grimeet/grimeet/common/config/swagger/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.grimeet.grimeet.common.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+            .info(new Info().title("Grimeet API")
+                    .description("그림으로 연결되는 우리 그리밋(Grim:eet) API")
+                    .version("v0.0.1")
+                    .contact(new Contact()
+                            .name("Grimeet")
+                            .email("jgoneit@gmail.com")
+                    )
+            ).servers(List.of(new Server().url("http://localhost:8081").description("Local Server"),
+                    new Server().url("https://api.grimeet.com").description("Production Server"))
+            ).components(new Components().addSecuritySchemes("bearer-jwt",
+                    new SecurityScheme().type(SecurityScheme.Type.HTTP)
+                            .scheme("bearer")
+                            .bearerFormat("JWT")
+                            .in(SecurityScheme.In.COOKIE)
+                            .name("Authorization_Access"))
+            ).addSecurityItem(new SecurityRequirement().addList("bearer-jwt"));
+  }
+}

--- a/src/main/java/com/grimeet/grimeet/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/controller/AuthController.java
@@ -7,6 +7,10 @@ import com.grimeet.grimeet.domain.auth.service.AuthService;
 import com.grimeet.grimeet.domain.user.dto.UserCreateRequestDto;
 import com.grimeet.grimeet.domain.user.dto.UserResponseDto;
 import com.grimeet.grimeet.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,23 +24,40 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
+@Tag(name = "Auth", description = "회원가입, 로그인, 로그아웃 API")
 public class AuthController {
 
   private final AuthService authService;
 
+  @Operation(summary = "회원가입", description = "회원가입을 진행합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "201", description = "회원가입 성공"),
+          @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
   @PostMapping("/register")
   public ResponseEntity<String> register(@Valid @RequestBody UserCreateRequestDto userCreateRequestDto) {
     authService.register(userCreateRequestDto);
     return ResponseEntity.status(HttpStatus.CREATED).body("회원가입이 완료되었습니다.");
   }
 
+  @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인을 진행합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "로그인 성공"),
+          @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
   @PostMapping("/login")
   public ResponseEntity<AuthResponseDto> login(@Valid @RequestBody UserLoginRequestDto userLoginRequestDto) {
     String accessToken = authService.login(userLoginRequestDto);
     return ResponseEntity.status(HttpStatus.OK).body(new AuthResponseDto(accessToken));
   }
 
-//  @PostMapping("/logout")
+  @Operation(summary = "로그아웃", description = "로그아웃을 진행합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "204", description = "로그아웃 성공"),
+          @ApiResponse(responseCode = "400", description = "잘못된 요청")
+  })
+  @PostMapping("/logout")
+  public void logout() {}
 //  public ResponseEntity<String> logout(@AuthenticationPrincipal(expression = "username") String userEmail) {
 //    authService.logout(userEmail);
 //    return ResponseEntity.status(HttpStatus.NO_CONTENT).body("로그아웃 되었습니다.");

--- a/src/main/java/com/grimeet/grimeet/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/dto/AuthResponseDto.java
@@ -1,10 +1,13 @@
 package com.grimeet.grimeet.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@Schema(description = "로그인 요청 응답")
 @Getter
 @AllArgsConstructor
 public class AuthResponseDto {
+  @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkb3BhbFByaW5jZXNzOTlAZ21haWwuY29tIiwiaWF0IjoxNjM0NzQwNjYwLCJleHAiOjE2MzQ3NDQyNjB9.7")
   private String AccessToken;
 }

--- a/src/main/java/com/grimeet/grimeet/domain/auth/dto/UserLoginRequestDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/dto/UserLoginRequestDto.java
@@ -1,5 +1,6 @@
 package com.grimeet.grimeet.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,7 +8,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserLoginRequestDto {
 
+  @Schema(description = "이메일(로그인 아이디)", example = "dopalPrincess98@gmail.com")
   private String email;
 
+  @Schema(description = "비밀번호", example = "test1234!#")
   private String password;
 }

--- a/src/main/java/com/grimeet/grimeet/domain/user/dto/UserCreateRequestDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/dto/UserCreateRequestDto.java
@@ -1,6 +1,7 @@
 package com.grimeet.grimeet.domain.user.dto;
 
 import com.grimeet.grimeet.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -12,23 +13,28 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class UserCreateRequestDto {
 
+  @Schema(description = "사용자 이름", example = "곽두팔")
   @NotBlank
   @Size(min = 2, max = 50)
   private String name;
 
+  @Schema(description = "이메일(로그인 아이디)", example = "dopalPrincess98@gmail.com")
   @NotBlank
   @Email
   @Size(max = 200)
   private String email;
 
+  @Schema(description = "비밀번호", example = "test1234!#")
   @NotBlank
   @Size(min = 8, max = 200)
   private String password;
 
+  @Schema(description = "닉네임", example = "zl존두팔S2")
   @NotBlank
   @Size(min = 2, max = 50)
   private String nickname;
 
+  @Schema(description = "전화번호", example = "010-1234-5678")
   @NotBlank
   @Size(max = 15)
   private String phoneNumber;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,3 +45,18 @@ jwt:
   refreshExpirationMs: ${GRIM_JWT_REFRESH_EXPIRATION_MS}
   token-prefix: Bearer
   header: Authorization
+
+springdoc:
+    packages-to-scan: com.grimeet.grimeet
+    default-consumes-media-type: application/json;charset=UTF-8
+    default-produces-media-type: application/json;charset=UTF-8
+    swagger-ui:
+      path: /swagger
+      doc-expansion: list # 문서 확장 방식 설정 -> none, list(default), full
+      filter: true # 필터 기능 활성화
+      disable-swagger-default-url: true
+      display-request-duration: true
+      operations-sorter: method  # operation 정렬방식 설정 -> alpha, method, order
+      deep-linking: true
+      syntax-highlight:
+        activated: true


### PR DESCRIPTION
## 🖍️ 이슈번호
<!-- 이슈 번호를 작성해 주세요. ex) #1 -->

- close #18 

## 🧑‍💻 작업사항

- [x] API 문서 자동화를 위한 Swagger API 셋팅
- [x] Swagger API 설정 파일 구현
- [x] AuthController 및 관련 Dto에 스키마 추가 및 문서정보 추가

## 📸 스크린샷

<!-- 필요한 경우 스크린샷을 첨부해주세요 -->

## 💡 참고사항

프론트엔드와 백엔드 간의 API 관련 소통에 있어 도움을 줄 수 있는 SwaggerAPI입니다.
일단 기초적으로 필요한 양식 관련해서 제가 작업한 Auth관련하여 작업을 추가했습니다.  머지 후 양식 숙지 및 적용 해주시면 감사하겠습니다 :)

스웨거 URL는 `/api/swagger` 입니다!

## 🙏 기타사항

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
