### PR TITLE
[feat] follower & following 기능 구현

### DIFF
--- a/src/main/java/com/grimeet/grimeet/GrimeetApplication.java
+++ b/src/main/java/com/grimeet/grimeet/GrimeetApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class GrimeetApplication {

--- a/src/main/java/com/grimeet/grimeet/common/batch/auth/AccessTokenRotateScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/auth/AccessTokenRotateScheduler.java
@@ -1,0 +1,4 @@
+package com.grimeet.grimeet.common.batch.auth;
+
+public class AccessTokenRotateScheduler {
+}

--- a/src/main/java/com/grimeet/grimeet/common/batch/auth/AccessTokenRotateScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/auth/AccessTokenRotateScheduler.java
@@ -1,4 +1,0 @@
-package com.grimeet.grimeet.common.batch.auth;
-
-public class AccessTokenRotateScheduler {
-}

--- a/src/main/java/com/grimeet/grimeet/common/batch/auth/RefreshTokenRotateScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/auth/RefreshTokenRotateScheduler.java
@@ -1,0 +1,4 @@
+package com.grimeet.grimeet.common.batch.auth;
+
+public class RefreshTokenRotateScheduler {
+}

--- a/src/main/java/com/grimeet/grimeet/common/batch/auth/RefreshTokenRotateScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/auth/RefreshTokenRotateScheduler.java
@@ -1,4 +1,0 @@
-package com.grimeet.grimeet.common.batch.auth;
-
-public class RefreshTokenRotateScheduler {
-}

--- a/src/main/java/com/grimeet/grimeet/common/batch/user/UserLogScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/user/UserLogScheduler.java
@@ -23,17 +23,26 @@ public class UserLogScheduler {
 
     @Scheduled(cron = "0 0 0 * * *")
     public void updateUserLogByDormantCheck() {
-        LocalDate now = LocalDate.now();
-        List<UserLog> userLogs = userLogRepository.findByNextDormantCheckDateLessThanEqual(now);
-        log.info("[스케줄러] 휴면 검사 대상 {}명 발견", userLogs.size());
+        try {
+            LocalDate now = LocalDate.now();
+            List<UserLog> userLogs = userLogRepository.findByNextDormantCheckDateLessThanEqual(now);
+            log.info("[UserLogScheduler] 휴면 검사 대상 {}명 발견", userLogs.size());
 
-        List<Long> userIds = userLogs.stream()
-                .map(UserLog::getUserId)
-                .toList();
+            if (userLogs.isEmpty()) {
+                return;
+            }
 
-        userService.updateUserStatusDormantBatch(userIds);
+            List<Long> userIds = userLogs.stream()
+                    .map(UserLog::getUserId)
+                    .toList();
 
-        log.info("[스케줄러] 휴면 전환 완료", userIds.size());
+            userService.updateUserStatusDormantBatch(userIds);
+
+            log.info("[UserLogScheduler] 휴면 전환 완료: 총 {}명 조회", userLogs.size());
+        } catch (Exception e) {
+            log.info("[UserLogScheduler] 휴면 전환 중 예외 발생: {}", e.getMessage(), e);
+        }
+
     }
 
 }

--- a/src/main/java/com/grimeet/grimeet/common/batch/user/UserLogScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/user/UserLogScheduler.java
@@ -1,7 +1,5 @@
 package com.grimeet.grimeet.common.batch.user;
 
-import com.grimeet.grimeet.domain.user.entity.User;
-import com.grimeet.grimeet.domain.user.repository.UserRepository;
 import com.grimeet.grimeet.domain.user.service.UserService;
 import com.grimeet.grimeet.domain.userLog.entity.UserLog;
 import com.grimeet.grimeet.domain.userLog.repository.UserLogRepository;

--- a/src/main/java/com/grimeet/grimeet/common/batch/user/UserLogScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/user/UserLogScheduler.java
@@ -1,8 +1,10 @@
 package com.grimeet.grimeet.common.batch.user;
 
+import com.grimeet.grimeet.domain.user.dto.UserStatus;
 import com.grimeet.grimeet.domain.user.service.UserService;
 import com.grimeet.grimeet.domain.userLog.entity.UserLog;
 import com.grimeet.grimeet.domain.userLog.repository.UserLogRepository;
+import com.grimeet.grimeet.domain.userLog.service.UserLogFacade;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -17,30 +19,27 @@ import java.util.List;
 public class UserLogScheduler {
 
     private final UserLogRepository userLogRepository;
-    private final UserService userService;
+    private final UserLogFacade userLogFacade;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 3 * * *")    // 매일 오전 3시
     public void updateUserLogByDormantCheck() {
         try {
             LocalDate now = LocalDate.now();
-            List<UserLog> userLogs = userLogRepository.findByNextDormantCheckDateLessThanEqual(now);
+            List<UserLog> userLogs = userLogRepository.findCandidatesForDormantCheck(now, List.of(UserStatus.NORMAL, UserStatus.SOCIAL));
             log.info("[UserLogScheduler] 휴면 검사 대상 {}명 발견", userLogs.size());
 
-            if (userLogs.isEmpty()) {
-                return;
-            }
+            if (userLogs.isEmpty()) return;
 
             List<Long> userIds = userLogs.stream()
                     .map(UserLog::getUserId)
                     .toList();
 
-            userService.updateUserStatusDormantBatch(userIds);
+            userLogFacade.convertUsersToDormant(userIds); // 💡 이 부분만 바꾼 것
 
-            log.info("[UserLogScheduler] 휴면 전환 완료: 총 {}명 조회", userLogs.size());
+            log.info("[UserLogScheduler] 휴면 전환 완료: 총 {}명 처리", userIds.size());
         } catch (Exception e) {
-            log.info("[UserLogScheduler] 휴면 전환 중 예외 발생: {}", e.getMessage(), e);
+            log.error("[UserLogScheduler] 예외 발생: {}", e.getMessage(), e);
         }
-
     }
 
 }

--- a/src/main/java/com/grimeet/grimeet/common/batch/user/UserPasswordChangeNotificationScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/user/UserPasswordChangeNotificationScheduler.java
@@ -1,0 +1,34 @@
+package com.grimeet.grimeet.common.batch.user;
+
+import com.grimeet.grimeet.domain.userLog.dto.UserLogResponseDto;
+import com.grimeet.grimeet.domain.userLog.service.UserLogService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserPasswordChangeNotificationScheduler {
+
+  private final UserLogService userLogService;
+
+  @Scheduled(cron = "0 0 3 * * *") // 매일 3시
+  public void notifyPasswordChange() {
+    log.info("📢 비밀번호 변경 알림 스케줄 시작");
+
+    List<UserLogResponseDto> targets = userLogService.findAllUserLogsForNotification();
+
+    targets.forEach(user -> {
+      // 알림 전송 로직
+//      notificationService.sendPasswordChangeNotice(user.getUserId());
+    });
+
+    // 추후 알림 관련 회의 이후 구현 예정
+
+    log.info("✅ 총 {}명의 사용자에게 알림 전송 완료", targets.size());
+  }
+}

--- a/src/main/java/com/grimeet/grimeet/common/batch/user/UserPasswordChangeNotificationScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/user/UserPasswordChangeNotificationScheduler.java
@@ -16,19 +16,22 @@ public class UserPasswordChangeNotificationScheduler {
 
   private final UserLogService userLogService;
 
-  @Scheduled(cron = "0 0 3 * * *") // 매일 3시
-  public void notifyPasswordChange() {
-    log.info("📢 비밀번호 변경 알림 스케줄 시작");
-
-    List<UserLogResponseDto> targets = userLogService.findAllUserLogsForNotification();
-
-    targets.forEach(user -> {
-      // 알림 전송 로직
+  /**
+   * 비밀번호 변경 알림 스케줄러(알림 기능 구현 후 활성화 예정)
+   */
+//  @Scheduled(cron = "0 0 3 * * *") // 매일 3시
+//  public void notifyPasswordChange() {
+//    log.info("📢 비밀번호 변경 알림 스케줄 시작");
+//
+//    List<UserLogResponseDto> targets = userLogService.findAllUserLogsForNotification();
+//
+//    targets.forEach(user -> {
+//      // 알림 전송 로직
 //      notificationService.sendPasswordChangeNotice(user.getUserId());
-    });
-
-    // 추후 알림 관련 회의 이후 구현 예정
-
-    log.info("✅ 총 {}명의 사용자에게 알림 전송 완료", targets.size());
-  }
+//    });
+//
+//    // 추후 알림 관련 회의 이후 구현 예정
+//
+//    log.info("✅ 총 {}명의 사용자에게 알림 전송 완료", targets.size());
+//  }
 }

--- a/src/main/java/com/grimeet/grimeet/common/batch/user/UserPasswordChangeNotificationScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/common/batch/user/UserPasswordChangeNotificationScheduler.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Slf4j
 public class UserPasswordChangeNotificationScheduler {
 
-  private final UserLogService userLogService;
+//  private final UserLogService userLogService;
 
   /**
    * 비밀번호 변경 알림 스케줄러(알림 기능 구현 후 활성화 예정)

--- a/src/main/java/com/grimeet/grimeet/common/config/security/CorsConfig.java
+++ b/src/main/java/com/grimeet/grimeet/common/config/security/CorsConfig.java
@@ -24,7 +24,7 @@ public class CorsConfig {
 
     corsConfiguration.setAllowCredentials(true);
 
-    corsConfiguration.setAllowedOriginPatterns(Arrays.asList("http://localhost:*", "https://*.grimeet.com"));
+    corsConfiguration.setAllowedOriginPatterns(Arrays.asList("http://localhost:*", "https://*.grimeet.com", "https://growing-choice-kingfish.ngrok-free.app"));
 
     corsConfiguration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
     corsConfiguration.addExposedHeader("Authorization");

--- a/src/main/java/com/grimeet/grimeet/common/config/security/SecurityConfig.java
+++ b/src/main/java/com/grimeet/grimeet/common/config/security/SecurityConfig.java
@@ -26,6 +26,7 @@ public class SecurityConfig {
   private final CorsConfig corsConfig;
   private final RefreshTokenRepository refreshTokenRepository;
   private final JwtUtil jwtUtil;
+  public static final String ACCESS_TOKEN_COOKIE_NAME = "Authorization_Access";
 
   /**
    * AuthenticationManager 빈 등록
@@ -99,9 +100,12 @@ public class SecurityConfig {
   }
 
   private static void removeCookie(HttpServletResponse response) {
-    Cookie cookie = new Cookie("Authorization_Access", null);
+    Cookie cookie = new Cookie(ACCESS_TOKEN_COOKIE_NAME, null);
     cookie.setMaxAge(0);
     cookie.setPath("/");
+    cookie.setHttpOnly(true);
+    cookie.setSecure(false);
+//    cookie.setDomain("grimeet.com");
     response.addCookie(cookie);
   }
 }

--- a/src/main/java/com/grimeet/grimeet/common/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/grimeet/grimeet/common/config/swagger/SwaggerConfig.java
@@ -26,6 +26,7 @@ public class SwaggerConfig {
                             .email("jgoneit@gmail.com")
                     )
             ).servers(List.of(new Server().url("http://localhost:8081").description("Local Server"),
+                    new Server().url("https://growing-choice-kingfish.ngrok-free.app").description("Ngrok Server"),
                     new Server().url("https://api.grimeet.com").description("Production Server"))
             ).components(new Components().addSecuritySchemes("bearer-jwt",
                     new SecurityScheme().type(SecurityScheme.Type.HTTP)

--- a/src/main/java/com/grimeet/grimeet/common/exception/ExceptionStatus.java
+++ b/src/main/java/com/grimeet/grimeet/common/exception/ExceptionStatus.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionStatus {
 
   // AUTH
+  INVALID_USER_LOGIN_INFO(HttpStatus.BAD_REQUEST, 400, "아이디 혹은 비밀번호가 일치하지 않습니다."),
 
   // JWT
   UN_AUTHENTICATION_TOKEN(HttpStatus.UNAUTHORIZED, 401, "토큰 정보가 없습니다."),
@@ -17,7 +18,6 @@ public enum ExceptionStatus {
   EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 400, "이미 존재하는 이메일입니다."),
   NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 400, "이미 존재하는 닉네임입니다."),
   PHONE_NUMBER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, 400, "이미 존재하는 전화번호입니다."),
-  INVALID_USER_LOGIN_INFO(HttpStatus.BAD_REQUEST, 400, "아이디 혹은 비밀번호가 일치하지 않습니다."),
   INVALID_PASSWORD(HttpStatus.BAD_REQUEST, 400, "비밀번호가 유효하지 않습니다."),
   INVALID_ROLE(HttpStatus.FORBIDDEN, 403, "접근할 수 없습니다."),
   INVALID_USER_STATUS(HttpStatus.BAD_REQUEST, 400, "잘못된 유저상태입니다."),
@@ -25,7 +25,10 @@ public enum ExceptionStatus {
   //UPLOAD
   INVALID_FILE(HttpStatus.BAD_REQUEST, 400, "유효하지 않은 이미지입니다."),
   S3_UPLOAD_FAIL(HttpStatus.BAD_REQUEST, 400, "S3 이미지 업로드에 실패했습니다."),
-  S3_DELETE_FAIL(HttpStatus.BAD_REQUEST, 400, "S3 이미지 삭제에 실패했습니다.");
+  S3_DELETE_FAIL(HttpStatus.BAD_REQUEST, 400, "S3 이미지 삭제에 실패했습니다."),
+
+  // FOLLOW
+  INVALID_FOLLOW(HttpStatus.BAD_REQUEST, 400, "잘못된 팔로우 요청입니다.");
 
   private final int status;
   private final int customCode;

--- a/src/main/java/com/grimeet/grimeet/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/controller/AuthController.java
@@ -1,5 +1,6 @@
 package com.grimeet.grimeet.domain.auth.controller;
 
+import com.grimeet.grimeet.domain.auth.dto.AuthLoginResponseDto;
 import com.grimeet.grimeet.domain.auth.dto.AuthResponseDto;
 import com.grimeet.grimeet.domain.auth.dto.TokenRefreshResponseDto;
 import com.grimeet.grimeet.domain.auth.dto.UserLoginRequestDto;
@@ -46,7 +47,7 @@ public class AuthController {
           @ApiResponse(responseCode = "400", description = "잘못된 요청")
   })
   @PostMapping("/login")
-  public ResponseEntity<AuthResponseDto> login(@Valid @RequestBody UserLoginRequestDto userLoginRequestDto, HttpServletResponse response) {
+  public ResponseEntity<AuthLoginResponseDto> login(@Valid @RequestBody UserLoginRequestDto userLoginRequestDto, HttpServletResponse response) {
     AuthResponseDto tokenDto = authService.login(userLoginRequestDto);
 
     Cookie cookie = new Cookie("Authorization_Access", tokenDto.getAccessToken());
@@ -58,7 +59,7 @@ public class AuthController {
 
     // AccessToken은 쿠키로 보내고, RefreshToken은 body로 응답
     // 이유는 AccessToken은 클라이언트에서 자주 사용되므로 쿠키에 저장하고, RefreshToken은 서버에서 관리하기 위함
-    return ResponseEntity.ok(AuthResponseDto.builder()
+    return ResponseEntity.ok(AuthLoginResponseDto.builder()
             .refreshToken(tokenDto.getRefreshToken())
             .isPasswordChangeRequired(tokenDto.getIsPasswordChangeRequired())
             .isDormant(tokenDto.getIsDormant())

--- a/src/main/java/com/grimeet/grimeet/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/controller/AuthController.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -52,7 +51,7 @@ public class AuthController {
 
     Cookie cookie = new Cookie("Authorization_Access", tokenDto.getAccessToken());
     cookie.setHttpOnly(true);
-    cookie.setSecure(false); // 운영 환경에서는 반드시 true
+    cookie.setSecure(true);
     cookie.setPath("/");
     cookie.setMaxAge(cookieMaxAge);
     response.addCookie(cookie);

--- a/src/main/java/com/grimeet/grimeet/domain/auth/dto/AuthLoginResponseDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/dto/AuthLoginResponseDto.java
@@ -9,15 +9,13 @@ import lombok.Getter;
  * 로그인 요청 응답 DTO
  *
  * @author : Jgone2
- * @since : 2025-04-21
+ * @since : 2025-04-22
  */
-@Schema(description = "로그인 요청 응답 - Service layer")
+@Schema(description = "로그인 요청 응답 - controller layer")
 @Builder
 @Getter
 @AllArgsConstructor
-public class AuthResponseDto {
-  @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkb3BhbFByaW5jZXNzOTlAZ21haWwuY29tIiwiaWF0IjoxNjM0NzQwNjYwLCJleHAiOjE2MzQ3NDQyNjB9.7")
-  private String accessToken;
+public class AuthLoginResponseDto {
   @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkb3BhbFByaW5jZXNzOTlAZ21haWwuY29tIiwiaWF0IjoxNjM0NzQwNjYwLCJleHAiOjE2MzQ3NDQyNjB917")
   private String refreshToken;
   @Schema(description = "비밀번호 변경 필요 여부, true: 필요, false: 불필요", example = "false")

--- a/src/main/java/com/grimeet/grimeet/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/dto/AuthResponseDto.java
@@ -2,12 +2,26 @@ package com.grimeet.grimeet.domain.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 로그인 요청 응답 DTO
+ *
+ * @author : Jgone2
+ * @since : 2025-04-21
+ */
 @Schema(description = "로그인 요청 응답")
+@Builder
 @Getter
 @AllArgsConstructor
 public class AuthResponseDto {
   @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkb3BhbFByaW5jZXNzOTlAZ21haWwuY29tIiwiaWF0IjoxNjM0NzQwNjYwLCJleHAiOjE2MzQ3NDQyNjB9.7")
-  private String AccessToken;
+  private String accessToken;
+  @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkb3BhbFByaW5jZXNzOTlAZ21haWwuY29tIiwiaWF0IjoxNjM0NzQwNjYwLCJleHAiOjE2MzQ3NDQyNjB917")
+  private String refreshToken;
+  @Schema(description = "비밀번호 변경 필요 여부, true: 필요, false: 불필요", example = "false")
+  private Boolean isPasswordChangeRequired;
+  @Schema(description = "휴면계정여부, true: 휴면, false: 비휴면", example = "false")
+  private Boolean isDormant;
 }

--- a/src/main/java/com/grimeet/grimeet/domain/auth/dto/TokenRefreshResponseDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/dto/TokenRefreshResponseDto.java
@@ -1,4 +1,23 @@
 package com.grimeet.grimeet.domain.auth.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 토큰 갱신 응답 DTO
+ *
+ * @Author : Jgone2
+ * @Since : 2025-04-21
+ */
+@Schema(description = "토큰 갱신 응답")
+@Getter
+@Builder
+@AllArgsConstructor
 public class TokenRefreshResponseDto {
+  @Schema(description = "액세스 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkb3BhbFByaW5jZXNzOTlAZ21haWwuY29tIiwiaWF0IjoxNjM0NzQwNjYwLCJleHAiOjE2MzQ3NDQyNjB9.7")
+  private String accessToken;
+  @Schema(description = "리프레시 토큰", example = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJkb3BhbFByaW5jZXNzOTlAZ21haWwuY29tIiwiaWF0IjoxNjM0NzQwNjYwLCJleHAiOjE2MzQ3NDQyNjB917")
+  private String refreshToken;
 }

--- a/src/main/java/com/grimeet/grimeet/domain/auth/dto/TokenRefreshResponseDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/dto/TokenRefreshResponseDto.java
@@ -1,0 +1,4 @@
+package com.grimeet.grimeet.domain.auth.dto;
+
+public class TokenRefreshResponseDto {
+}

--- a/src/main/java/com/grimeet/grimeet/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/entity/RefreshToken.java
@@ -4,6 +4,7 @@ package com.grimeet.grimeet.domain.auth.entity;
 import com.grimeet.grimeet.common.entity.BaseTime;
 import jakarta.persistence.*;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,10 +12,12 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(name = "REFRESH_TOKENS")
+@EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class RefreshToken extends BaseTime {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @EqualsAndHashCode.Include
   private Long id;
 
   @Column(name = "user_email", length = 255, nullable = false, unique = true, updatable = false)

--- a/src/main/java/com/grimeet/grimeet/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/entity/RefreshToken.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @Table(name = "REFRESH_TOKENS")
-@EqualsAndHashCode(onlyExplicitlyIncluded = true)
+@EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 public class RefreshToken extends BaseTime {
 
   @Id

--- a/src/main/java/com/grimeet/grimeet/domain/auth/entity/RefreshToken.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/entity/RefreshToken.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-@Table(name = "REFRESH_TOKENS")
+@Table(name = "refresh_tokens")
 @EqualsAndHashCode(callSuper = false, onlyExplicitlyIncluded = true)
 public class RefreshToken extends BaseTime {
 

--- a/src/main/java/com/grimeet/grimeet/domain/auth/service/AuthService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.grimeet.grimeet.domain.auth.service;
 
 import com.grimeet.grimeet.domain.auth.dto.AuthResponseDto;
+import com.grimeet.grimeet.domain.auth.dto.TokenRefreshResponseDto;
 import com.grimeet.grimeet.domain.auth.dto.UserLoginRequestDto;
 import com.grimeet.grimeet.domain.user.dto.UserCreateRequestDto;
 import com.grimeet.grimeet.domain.user.dto.UserResponseDto;
@@ -8,9 +9,9 @@ import com.grimeet.grimeet.domain.user.dto.UserResponseDto;
 public interface AuthService {
   UserResponseDto register(UserCreateRequestDto userCreateRequestDto);
 
-  AuthResponseDto createAccessToken(String refreshToken);
+  TokenRefreshResponseDto createAccessToken(String refreshToken);
 
-  String login(UserLoginRequestDto userLoginRequestDto);
+  AuthResponseDto login(UserLoginRequestDto userLoginRequestDto);
 
-  void logout(String userEmail);
+//  void logout(String userEmail);
 }

--- a/src/main/java/com/grimeet/grimeet/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/auth/service/AuthServiceImpl.java
@@ -14,6 +14,7 @@ import com.grimeet.grimeet.domain.user.dto.UserStatus;
 import com.grimeet.grimeet.domain.user.entity.User;
 import com.grimeet.grimeet.domain.user.repository.UserRepository;
 import com.grimeet.grimeet.domain.user.service.UserDetailServiceImpl;
+import com.grimeet.grimeet.domain.userLog.service.UserLogService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +31,7 @@ public class AuthServiceImpl implements AuthService {
   private final RefreshTokenRepository refreshTokenRepository;
   private final UserDetailServiceImpl userDetailService;
   private final UserRepository userRepository;
+  private final UserLogService userLogService;
   private final BCryptPasswordEncoder passwordEncoder;
 
   @Override
@@ -42,6 +44,9 @@ public class AuthServiceImpl implements AuthService {
     User createdUser = userCreateRequestDto.toEntity(userCreateRequestDto, encryptedPassword);
 
     userRepository.save(createdUser);
+    // 회원가입 시 사용자 로그 생성
+    userLogService.createUserLog(createdUser.getEmail());
+
 
     return new UserResponseDto(createdUser);
   }

--- a/src/main/java/com/grimeet/grimeet/domain/follower/controller/FollowController.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/controller/FollowController.java
@@ -1,0 +1,4 @@
+package com.grimeet.grimeet.domain.follower.controller;
+
+public class FollowerController {
+}

--- a/src/main/java/com/grimeet/grimeet/domain/follower/controller/FollowController.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/controller/FollowController.java
@@ -1,4 +1,64 @@
 package com.grimeet.grimeet.domain.follower.controller;
 
-public class FollowerController {
+import com.grimeet.grimeet.domain.follower.dto.FollowRequestDto;
+import com.grimeet.grimeet.domain.follower.dto.UserSummaryResponseDto;
+import com.grimeet.grimeet.domain.follower.service.FollowService;
+import com.grimeet.grimeet.domain.user.entity.User;
+import com.grimeet.grimeet.common.config.oauth.UserPrincipalDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/follow")
+@RequiredArgsConstructor
+@Tag(name = "Follow", description = "팔로우 API")
+public class FollowController {
+
+  private final FollowService followService;
+
+  @Operation(summary = "팔로우 토글", description = "현재 로그인된 사용자가 특정 유저를 팔로우 또는 언팔로우합니다.")
+  @PostMapping()
+  public ResponseEntity<Void> toggleFollow(
+          @AuthenticationPrincipal UserPrincipalDetails userDetails,
+          @RequestBody FollowRequestDto request
+  ) {
+    Long followerId = userDetails.getUser().getId();
+    followService.follow(followerId, request.getFollowingId());
+    return ResponseEntity.ok().build();
+  }
+  @Operation(summary = "팔로워 목록 조회", description = "특정 유저를 팔로우한 사용자 목록을 조회합니다.")
+  @GetMapping("/followers/{userId}")
+  public ResponseEntity<List<UserSummaryResponseDto>> getFollowers(@PathVariable Long userId) {
+    List<UserSummaryResponseDto> followers = followService.getFollowers(userId).stream()
+            .map(UserSummaryResponseDto::from)
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(followers);
+  }
+
+  @Operation(summary = "팔로잉 목록 조회", description = "특정 유저가 팔로우한 사용자 목록을 조회합니다.")
+  @GetMapping("/followings/{userId}")
+  public ResponseEntity<List<UserSummaryResponseDto>> getFollowings(@PathVariable Long userId) {
+    List<UserSummaryResponseDto> followings = followService.getFollowings(userId).stream()
+            .map(UserSummaryResponseDto::from)
+            .collect(Collectors.toList());
+    return ResponseEntity.ok(followings);
+  }
+
+  @Operation(summary = "팔로우 여부 확인", description = "현재 로그인한 사용자가 특정 유저를 팔로우 중인지 확인합니다.")
+  @GetMapping("/is-following")
+  public ResponseEntity<Boolean> isFollowing(
+          @AuthenticationPrincipal UserPrincipalDetails userDetails,
+          @RequestParam Long followingId
+  ) {
+    Long followerId = userDetails.getUser().getId();
+    boolean result = followService.isFollowing(followerId, followingId);
+    return ResponseEntity.ok(result);
+  }
 }

--- a/src/main/java/com/grimeet/grimeet/domain/follower/dto/FollowRequestDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/dto/FollowRequestDto.java
@@ -1,4 +1,12 @@
 package com.grimeet.grimeet.domain.follower.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class FollowRequestDto {
+  @Schema(description = "팔로우할 대상 유저 ID", example = "2")
+  private Long followingId;
 }

--- a/src/main/java/com/grimeet/grimeet/domain/follower/dto/FollowRequestDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/dto/FollowRequestDto.java
@@ -1,0 +1,4 @@
+package com.grimeet.grimeet.domain.follower.dto;
+
+public class FollowRequestDto {
+}

--- a/src/main/java/com/grimeet/grimeet/domain/follower/dto/UserSummaryResponseDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/dto/UserSummaryResponseDto.java
@@ -1,4 +1,29 @@
 package com.grimeet.grimeet.domain.follower.dto;
 
+import com.grimeet.grimeet.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "간단한 유저 정보 응답 DTO")
+@Getter
+@Builder
+@AllArgsConstructor
 public class UserSummaryResponseDto {
+
+  @Schema(description = "유저 ID", example = "1")
+  private Long id;
+  @Schema(description = "유저 닉네임", example = "jaegon98")
+  private String nickname;
+  @Schema(description = "프로필 이미지 URL", example = "https://s3.aws.com/image/profile.jpg")
+  private String profileImageUrl;
+
+  public static UserSummaryResponseDto from(User user) {
+    return new UserSummaryResponseDto(
+            user.getId(),
+            user.getNickname(),
+            user.getProfileImageUrl()
+    );
+  }
 }

--- a/src/main/java/com/grimeet/grimeet/domain/follower/dto/UserSummaryResponseDto.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/dto/UserSummaryResponseDto.java
@@ -1,0 +1,4 @@
+package com.grimeet.grimeet.domain.follower.dto;
+
+public class UserSummaryResponseDto {
+}

--- a/src/main/java/com/grimeet/grimeet/domain/follower/entity/Follower.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/entity/Follower.java
@@ -1,0 +1,38 @@
+package com.grimeet.grimeet.domain.follower.entity;
+
+import com.grimeet.grimeet.common.entity.BaseTime;
+import com.grimeet.grimeet.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "followers",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"follower_id", "following_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Follower extends BaseTime {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // 내가 팔로우한 사용자
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "follower_id", nullable = false)
+  private User follower;
+
+  // 내가 팔로우한 대상
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "following_id", nullable = false)
+  private User following;
+
+  @Builder
+  public Follower(User follower, User following) {
+    this.follower = follower;
+    this.following = following;
+  }
+}

--- a/src/main/java/com/grimeet/grimeet/domain/follower/repository/FollowRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/repository/FollowRepository.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 @Repository
-public interface FollowerRepository extends JpaRepository<Follower, Long> {
+public interface FollowRepository extends JpaRepository<Follower, Long> {
 
     Optional<Follower> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
     List<Follower> findAllByFollowingId(Long userId);

--- a/src/main/java/com/grimeet/grimeet/domain/follower/repository/FollowRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/repository/FollowRepository.java
@@ -1,0 +1,18 @@
+package com.grimeet.grimeet.domain.follower.repository;
+
+import com.grimeet.grimeet.domain.follower.entity.Follower;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface FollowerRepository extends JpaRepository<Follower, Long> {
+
+    Optional<Follower> findByFollowerIdAndFollowingId(Long followerId, Long followingId);
+    List<Follower> findAllByFollowingId(Long userId);
+    List<Follower> findAllByFollowerId(Long userId);
+    boolean existsByFollowerIdAndFollowingId(Long followerId, Long followingId);
+    void deleteByFollowerIdAndFollowingId(Long followerId, Long followingId);
+}

--- a/src/main/java/com/grimeet/grimeet/domain/follower/service/FollowService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/service/FollowService.java
@@ -1,0 +1,15 @@
+package com.grimeet.grimeet.domain.follower.service;
+
+import com.grimeet.grimeet.domain.user.entity.User;
+
+import java.util.List;
+
+public interface FollowerService {
+
+  void follow(Long followerId, Long followingId);         // 팔로우 수행
+  void unfollow(Long followerId, Long followingId);       // 언팔로우 수행
+  boolean isFollowing(Long followerId, Long followingId); // 팔로우 여부 확인
+
+  List<User> getFollowers(Long userId);   // 나를 팔로우한 사람 목록
+  List<User> getFollowings(Long userId);  // 내가 팔로우한 사람 목록
+}

--- a/src/main/java/com/grimeet/grimeet/domain/follower/service/FollowService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/service/FollowService.java
@@ -4,10 +4,9 @@ import com.grimeet.grimeet.domain.user.entity.User;
 
 import java.util.List;
 
-public interface FollowerService {
+public interface FollowService {
 
   void follow(Long followerId, Long followingId);         // 팔로우 수행
-  void unfollow(Long followerId, Long followingId);       // 언팔로우 수행
   boolean isFollowing(Long followerId, Long followingId); // 팔로우 여부 확인
 
   List<User> getFollowers(Long userId);   // 나를 팔로우한 사람 목록

--- a/src/main/java/com/grimeet/grimeet/domain/follower/service/FollowServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/service/FollowServiceImpl.java
@@ -1,0 +1,91 @@
+package com.grimeet.grimeet.domain.follower.service;
+
+import com.grimeet.grimeet.common.exception.ExceptionStatus;
+import com.grimeet.grimeet.common.exception.GrimeetException;
+import com.grimeet.grimeet.domain.follower.entity.Follower;
+import com.grimeet.grimeet.domain.follower.repository.FollowerRepository;
+import com.grimeet.grimeet.domain.user.entity.User;
+import com.grimeet.grimeet.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FollowerServiceImpl implements FollowerService {
+
+  private final FollowerRepository followerRepository;
+  private final UserRepository userRepository;
+
+  @Override
+  public void follow(Long followerId, Long followingId) {
+    // 팔로우 시도 시 자기 자신을 팔로우하는 경우 예외 발생(혹시나..)
+    checkTryToFollowSelf(followerId, followingId);
+
+    // 이미 팔로우 중인 관계라면 언팔로우 수행
+    if (checkFollowingNow(followerId, followingId)) return;
+
+    User follower = isAlreadyFollowingAndUnfollowIfTrue(followerId);
+    User following = isAlreadyFollowingAndUnfollowIfTrue(followingId);
+
+    Follower newFollow = Follower.builder()
+            .follower(follower)
+            .following(following)
+            .build();
+
+    followerRepository.save(newFollow);
+  }
+
+  @Override
+  public void unfollow(Long followerId, Long followingId) {
+    followerRepository.deleteByFollowerIdAndFollowingId(followerId, followingId);
+  }
+
+  @Override
+  public boolean isFollowing(Long followerId, Long followingId) {
+    return followerRepository.existsByFollowerIdAndFollowingId(followerId, followingId);
+  }
+
+  @Override
+  public List<User> getFollowers(Long userId) {
+    return followerRepository.findAllByFollowingId(userId).stream()
+            .map(Follower::getFollower)
+            .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<User> getFollowings(Long userId) {
+    return followerRepository.findAllByFollowerId(userId).stream()
+            .map(Follower::getFollowing)
+            .collect(Collectors.toList());
+  }
+
+  private User isAlreadyFollowingAndUnfollowIfTrue(Long followerId) {
+    return userRepository.findById(followerId)
+            .orElseThrow(() -> new GrimeetException(ExceptionStatus.USER_NOT_FOUND));
+  }
+
+  private boolean checkFollowingNow(Long followerId, Long followingId) {
+    Optional<Follower> existing = followerRepository.findByFollowerIdAndFollowingId(followerId, followingId);
+
+    if (existing.isPresent()) {
+      // 이미 팔로우된 상태면 언팔로우 수행
+      followerRepository.deleteByFollowerIdAndFollowingId(followerId, followingId);
+      return true;
+    }
+    return false;
+  }
+
+  private static void checkTryToFollowSelf(Long followerId, Long followingId) {
+    if (followerId.equals(followingId)) {
+      throw new GrimeetException(ExceptionStatus.INVALID_FOLLOW);
+    }
+  }
+}

--- a/src/main/java/com/grimeet/grimeet/domain/follower/service/FollowServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/follower/service/FollowServiceImpl.java
@@ -3,7 +3,7 @@ package com.grimeet.grimeet.domain.follower.service;
 import com.grimeet.grimeet.common.exception.ExceptionStatus;
 import com.grimeet.grimeet.common.exception.GrimeetException;
 import com.grimeet.grimeet.domain.follower.entity.Follower;
-import com.grimeet.grimeet.domain.follower.repository.FollowerRepository;
+import com.grimeet.grimeet.domain.follower.repository.FollowRepository;
 import com.grimeet.grimeet.domain.user.entity.User;
 import com.grimeet.grimeet.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -19,9 +19,9 @@ import java.util.stream.Collectors;
 @Service
 @Transactional
 @RequiredArgsConstructor
-public class FollowerServiceImpl implements FollowerService {
+public class FollowServiceImpl implements FollowService {
 
-  private final FollowerRepository followerRepository;
+  private final FollowRepository followerRepository;
   private final UserRepository userRepository;
 
   @Override
@@ -41,11 +41,6 @@ public class FollowerServiceImpl implements FollowerService {
             .build();
 
     followerRepository.save(newFollow);
-  }
-
-  @Override
-  public void unfollow(Long followerId, Long followingId) {
-    followerRepository.deleteByFollowerIdAndFollowingId(followerId, followingId);
   }
 
   @Override

--- a/src/main/java/com/grimeet/grimeet/domain/user/entity/User.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/entity/User.java
@@ -9,7 +9,7 @@ import lombok.*;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
-@Table(name = "USERS")
+@Table(name = "users")
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/grimeet/grimeet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/repository/UserRepository.java
@@ -1,24 +1,22 @@
 package com.grimeet.grimeet.domain.user.repository;
 
-import com.grimeet.grimeet.domain.user.dto.UserResponseDto;
 import com.grimeet.grimeet.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Integer> {
-    /**
-     * 이메일로 유저 정보를 조회하는 메서드
-     * @param email
-     * @return Optional<User>
-     */
-    Optional<User> findUserByEmail(String email); // Optional을 사용하면 null 체크를 하지 않아도 된다. NullPointException을 방지할 수 있다.
 
     Optional<User> findById(Long id);
 
     Optional<User> findByEmail(String email);
+
+    List<User> findByIdIn(List<Long> ids);
 
     Boolean existsByEmail(String email);
 

--- a/src/main/java/com/grimeet/grimeet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/repository/UserRepository.java
@@ -1,6 +1,5 @@
 package com.grimeet.grimeet.domain.user.repository;
 
-import com.grimeet.grimeet.domain.user.dto.UserResponseDto;
 import com.grimeet.grimeet.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,7 +7,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface UserRepository extends JpaRepository<User, Integer> {
+public interface UserRepository extends JpaRepository<User, Long> {
     /**
      * 이메일로 유저 정보를 조회하는 메서드
      * @param email

--- a/src/main/java/com/grimeet/grimeet/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/repository/UserRepository.java
@@ -1,5 +1,6 @@
 package com.grimeet.grimeet.domain.user.repository;
 
+import com.grimeet.grimeet.domain.user.dto.UserStatus;
 import com.grimeet.grimeet.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -16,7 +17,12 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByEmail(String email);
 
-    List<User> findByIdIn(List<Long> ids);
+    @Query("""
+        SELECT u FROM User u
+        WHERE u.id IN :ids
+        AND u.userStatus IN :statuses
+    """)
+    List<User> findByIdInAndUserStatusIn(@Param("ids")List<Long> ids, @Param("statuses")List<UserStatus> statuses);
 
     Boolean existsByEmail(String email);
 

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserService.java
@@ -17,7 +17,10 @@ public interface UserService {
 
     // 휴면 회원으로 전환
     void updateUserStatusDormant(String email);
-  
+
+    // 스케줄러 -> 휴면 회원들로 전환
+    void updateUserStatusDormantBatch(List<Long> ids);
+
     // 일반 회원으로 전환
     void updateUserStatusNormal(String email);
 

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserService.java
@@ -9,9 +9,6 @@ public interface UserService {
     // email로 유저 찾기
     UserResponseDto findUserByEmail(String email);
 
-    // 전체 유저 조회
-    List<User> findAllUsers();
-
     // 탈퇴 회원으로 전환
     void updateUserStatusWithdrawal(String email);
 

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserService.java
@@ -1,14 +1,13 @@
 package com.grimeet.grimeet.domain.user.service;
 
 import com.grimeet.grimeet.domain.user.dto.*;
-import com.grimeet.grimeet.domain.user.entity.User;
 
 import java.util.List;
 
 public interface UserService {
 
     // email로 유저 찾기
-    User findUserByEmail(String email);
+    UserResponseDto findUserByEmail(String email);
 
     // 전체 유저 조회
     List<UserCreateRequestDto> findAllUsers();

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.grimeet.grimeet.domain.user.service;
 
 import com.grimeet.grimeet.domain.user.dto.*;
+import com.grimeet.grimeet.domain.user.entity.User;
 
 import java.util.List;
 
@@ -10,7 +11,7 @@ public interface UserService {
     UserResponseDto findUserByEmail(String email);
 
     // 전체 유저 조회
-    List<UserCreateRequestDto> findAllUsers();
+    List<User> findAllUsers();
 
     // 탈퇴 회원으로 전환
     void updateUserStatusWithdrawal(String email);

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -61,20 +62,17 @@ public class UserServiceImpl implements UserService {
     public void updateUserStatusDormantBatch(List<Long> ids) {
         List<User> users = userRepository.findByIdIn(ids);  // 한번에 조회
 
-        List<Long> foundIds = users.stream()
-                .map(User::getId)
-                .toList();
-
-        List<Long> notFoundIds = ids.stream()
-                .filter(id -> !foundIds.contains(id))
-                .toList();
+        // 일반, 소셜 회원만 조회 -> 휴면 전환
+        int successCount = 0;
 
         for (User user : users) {
-            user.setUserStatus(UserStatus.DORMANT);
+            if (user.getUserStatus() == UserStatus.NORMAL || user.getUserStatus() == UserStatus.SOCIAL) {
+                user.setUserStatus(UserStatus.DORMANT);
+                successCount++;
+            }
         }
 
-        log.info("[UserService] 휴면 처리 완료 → 총 {}, 실패 {}", users.size(), notFoundIds.size());
-
+        log.info("[UserService] 휴면 처리 완료 → 조회: 총 {}, 휴면 전환 성공: {}", users.size(), successCount);
     }
 
     // 유저 상태 휴면 전환

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
@@ -30,10 +30,10 @@ public class UserServiceImpl implements UserService {
     // email로 유저 찾기
     @Transactional
     @Override
-    public User findUserByEmail(String email) {
+    public UserResponseDto findUserByEmail(String email) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new GrimeetException(ExceptionStatus.USER_NOT_FOUND));
-        return user;
+        return new UserResponseDto(user);
     }
 
     // 전체 유저 조회

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import com.grimeet.grimeet.domain.upload.service.S3ImageService;
 import com.grimeet.grimeet.domain.user.dto.*;
 import com.grimeet.grimeet.domain.user.entity.User;
 import com.grimeet.grimeet.domain.user.repository.UserRepository;
+import com.grimeet.grimeet.domain.userLog.service.UserLogService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final UserLogService userLogService;
     private final S3ImageService s3ImageService;
 
     // email로 유저 찾기
@@ -114,6 +116,7 @@ public class UserServiceImpl implements UserService {
         verifyCurrentPasswordMatches(requestDto.getCurrentPassword(), user.getPassword());
 
         user.setPassword(passwordEncoder.encode(requestDto.getNewPassword()));
+        userLogService.updateUserLogByPassword(user.getEmail());
 
         return new UserResponseDto(user);
     }

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
@@ -47,7 +47,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     @Override
     public void updateUserStatusWithdrawal(String email) {
-        Optional<User> optionalUser = userRepository.findUserByEmail(email);
+        Optional<User> optionalUser = userRepository.findByEmail(email);
 
         if (optionalUser.isEmpty()) {
             throw new GrimeetException(ExceptionStatus.USER_NOT_FOUND);
@@ -56,11 +56,32 @@ public class UserServiceImpl implements UserService {
         user.setUserStatus(UserStatus.WITHDRAWAL);
     }
 
+    @Transactional
+    @Override
+    public void updateUserStatusDormantBatch(List<Long> ids) {
+        List<User> users = userRepository.findByIdIn(ids);  // 한번에 조회
+
+        List<Long> foundIds = users.stream()
+                .map(User::getId)
+                .toList();
+
+        List<Long> notFoundIds = ids.stream()
+                .filter(id -> !foundIds.contains(id))
+                .toList();
+
+        for (User user : users) {
+            user.setUserStatus(UserStatus.DORMANT);
+        }
+
+        log.info("[UserService] 휴면 처리 완료 → 총 {}, 실패 {}", users.size(), notFoundIds.size());
+
+    }
+
     // 유저 상태 휴면 전환
     @Transactional
     @Override
     public void updateUserStatusDormant(String email) {
-        Optional<User> optionalUser = userRepository.findUserByEmail(email);
+        Optional<User> optionalUser = userRepository.findByEmail(email);
 
         if (optionalUser.isEmpty()) {
             throw new GrimeetException(ExceptionStatus.USER_NOT_FOUND);
@@ -73,7 +94,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     @Override
     public void updateUserStatusNormal(String email) {
-        Optional<User> optionalUser = userRepository.findUserByEmail(email);
+        Optional<User> optionalUser = userRepository.findByEmail(email);
 
         if (optionalUser.isEmpty()) {
             throw new GrimeetException(ExceptionStatus.USER_NOT_FOUND);

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
@@ -16,7 +16,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 
 @Slf4j
@@ -40,7 +39,7 @@ public class UserServiceImpl implements UserService {
     // 전체 유저 조회
     @Transactional
     @Override
-    public List<UserCreateRequestDto> findAllUsers() {
+    public List<User> findAllUsers() {
         return List.of();
     }
 
@@ -61,7 +60,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public void updateUserStatusDormantBatch(List<Long> ids) {
         try {
-            List<User> users = userRepository.findByIdIn(ids);  // 한번에 조회
+            List<User> users = userRepository.findByIdInAndUserStatusIn(ids, List.of(UserStatus.NORMAL, UserStatus.SOCIAL));  // 한번에 조회
 
             // 일반, 소셜 회원만 조회 -> 휴면 전환
             int successCount = 0;

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
@@ -8,7 +8,7 @@ import com.grimeet.grimeet.domain.upload.service.S3ImageService;
 import com.grimeet.grimeet.domain.user.dto.*;
 import com.grimeet.grimeet.domain.user.entity.User;
 import com.grimeet.grimeet.domain.user.repository.UserRepository;
-import com.grimeet.grimeet.domain.userLog.service.UserLogService;
+import com.grimeet.grimeet.domain.userLog.service.UserLogFacade;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,7 +26,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
-    private final UserLogService userLogService;
+    private final UserLogFacade userLogFacade;
     private final S3ImageService s3ImageService;
 
     // email로 유저 찾기
@@ -36,13 +36,6 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new GrimeetException(ExceptionStatus.USER_NOT_FOUND));
         return new UserResponseDto(user);
-    }
-
-    // 전체 유저 조회
-    @Transactional
-    @Override
-    public List<User> findAllUsers() {
-        return List.of();
     }
 
     // 유저 상태 탈퇴 전환
@@ -140,7 +133,7 @@ public class UserServiceImpl implements UserService {
         verifyCurrentPasswordMatches(requestDto.getCurrentPassword(), user.getPassword());
 
         user.setPassword(passwordEncoder.encode(requestDto.getNewPassword()));
-        userLogService.updateUserLogByPassword(user.getEmail());
+        userLogFacade.updatePasswordLog(user.getId());
 
         return new UserResponseDto(user);
     }

--- a/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/user/service/UserServiceImpl.java
@@ -60,19 +60,25 @@ public class UserServiceImpl implements UserService {
     @Transactional
     @Override
     public void updateUserStatusDormantBatch(List<Long> ids) {
-        List<User> users = userRepository.findByIdIn(ids);  // 한번에 조회
+        try {
+            List<User> users = userRepository.findByIdIn(ids);  // 한번에 조회
 
-        // 일반, 소셜 회원만 조회 -> 휴면 전환
-        int successCount = 0;
+            // 일반, 소셜 회원만 조회 -> 휴면 전환
+            int successCount = 0;
 
-        for (User user : users) {
-            if (user.getUserStatus() == UserStatus.NORMAL || user.getUserStatus() == UserStatus.SOCIAL) {
-                user.setUserStatus(UserStatus.DORMANT);
-                successCount++;
+            for (User user : users) {
+                if (user.getUserStatus() == UserStatus.NORMAL || user.getUserStatus() == UserStatus.SOCIAL) {
+                    user.setUserStatus(UserStatus.DORMANT);
+                    successCount++;
+                }
             }
+
+            log.info("[UserService] 휴면 처리 완료 → 조회: 총 {}, 휴면 전환 성공: {}", users.size(), successCount);
+        } catch (Exception e) {
+            log.info("[UserService] 휴면 상태 일괄 전환 중 예외 발생: {}", e.getMessage());
+            // 알림이나 감지 필요 시 추가
         }
 
-        log.info("[UserService] 휴면 처리 완료 → 조회: 총 {}, 휴면 전환 성공: {}", users.size(), successCount);
     }
 
     // 유저 상태 휴면 전환

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/entity/UserLog.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/entity/UserLog.java
@@ -11,7 +11,7 @@ import java.time.LocalDate;
 import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Entity
-@Table(name = "USER_LOGS")
+@Table(name = "user_logs")
 @Getter
 @Builder
 @NoArgsConstructor

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/entity/UserLog.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/entity/UserLog.java
@@ -26,7 +26,7 @@ public class UserLog extends BaseTime {
 
   @Schema(description = "마지막 로그인 일시", example = "2024-10-01 00:00:00")
   @Comment("마지막 로그인 일시")
-  @Column(name = "last_login_at", nullable = false, updatable = true, columnDefinition = "DATETIME")
+  @Column(name = "last_login_at", nullable = false, updatable = true, columnDefinition = "DATE")
   private LocalDate lastLoginAt;
 
   @Schema(description = "최근 비밀번호 변경 일시", example = "2024-10-01 00:00:00")
@@ -36,7 +36,7 @@ public class UserLog extends BaseTime {
 
   @Schema(description = "휴면 상태 전환 예정일", example = "2023-10-01 00:00:00")
   @Comment("휴면 상태 전환 예정일")
-  @Column(name = "next_dormant_check_date", nullable = false, updatable = true, columnDefinition = "DATET")
+  @Column(name = "next_dormant_check_date", nullable = false, updatable = true, columnDefinition = "DATE")
   private LocalDate nextDormantCheckDate;
 
   @Schema(description = "다음 비밀번호 변경 알림 예정일", example = "2024-11-01 00:00:00")

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/entity/UserLog.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/entity/UserLog.java
@@ -26,26 +26,22 @@ public class UserLog extends BaseTime {
 
   @Schema(description = "마지막 로그인 일시", example = "2024-10-01 00:00:00")
   @Comment("마지막 로그인 일시")
-  @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "last_login_at", nullable = false, updatable = true, columnDefinition = "DATETIME")
   private LocalDate lastLoginAt;
 
   @Schema(description = "최근 비밀번호 변경 일시", example = "2024-10-01 00:00:00")
   @Comment("최근 비밀번호 변경 일시")
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "changed_password_at", nullable = false, updatable = true, columnDefinition = "DATETIME")
+  @Column(name = "changed_password_at", nullable = false, updatable = true, columnDefinition = "DATE")
   private LocalDate changedPasswordAt;
 
   @Schema(description = "휴면 상태 전환 예정일", example = "2023-10-01 00:00:00")
   @Comment("휴면 상태 전환 예정일")
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "next_dormant_check_date", nullable = false, updatable = true, columnDefinition = "DATETIME")
+  @Column(name = "next_dormant_check_date", nullable = false, updatable = true, columnDefinition = "DATET")
   private LocalDate nextDormantCheckDate;
 
   @Schema(description = "다음 비밀번호 변경 알림 예정일", example = "2024-11-01 00:00:00")
   @Comment("다음 비밀번호 변경 알림 예정일")
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "next_notification_date", nullable = false, updatable = true, columnDefinition = "DATETIME")
+  @Column(name = "next_notification_date", nullable = false, updatable = true, columnDefinition = "DATE")
   private LocalDate nextNotificationDate;
 
   @Schema(description = "사용자 ID", example = "1")

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/entity/UserLog.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/entity/UserLog.java
@@ -24,28 +24,24 @@ public class UserLog extends BaseTime {
   @Column(name = "user_log_id")
   private Long id;
 
-  @Schema(description = "마지막 로그인 일시", example = "2024-10-01 00:00:00")
+  @Schema(description = "마지막 로그인 일시", example = "2024-10-01")
   @Comment("마지막 로그인 일시")
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "last_login_at", nullable = false, updatable = true, columnDefinition = "DATETIME")
+  @Column(name = "last_login_at", nullable = false, updatable = true, columnDefinition = "DATE")
   private LocalDate lastLoginAt;
 
-  @Schema(description = "최근 비밀번호 변경 일시", example = "2024-10-01 00:00:00")
+  @Schema(description = "최근 비밀번호 변경 일시", example = "2024-10-01")
   @Comment("최근 비밀번호 변경 일시")
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "changed_password_at", nullable = false, updatable = true, columnDefinition = "DATETIME")
+  @Column(name = "changed_password_at", nullable = false, updatable = true, columnDefinition = "DATE")
   private LocalDate changedPasswordAt;
 
-  @Schema(description = "휴면 상태 전환 예정일", example = "2023-10-01 00:00:00")
+  @Schema(description = "휴면 상태 전환 예정일", example = "2023-10-01")
   @Comment("휴면 상태 전환 예정일")
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "next_dormant_check_date", nullable = false, updatable = true, columnDefinition = "DATETIME")
+  @Column(name = "next_dormant_check_date", nullable = false, updatable = true, columnDefinition = "DATE")
   private LocalDate nextDormantCheckDate;
 
-  @Schema(description = "다음 비밀번호 변경 알림 예정일", example = "2024-11-01 00:00:00")
+  @Schema(description = "다음 비밀번호 변경 알림 예정일", example = "2024-11-01")
   @Comment("다음 비밀번호 변경 알림 예정일")
-  @Temporal(TemporalType.TIMESTAMP)
-  @Column(name = "next_notification_date", nullable = false, updatable = true, columnDefinition = "DATETIME")
+  @Column(name = "next_notification_date", nullable = false, updatable = true, columnDefinition = "DATE")
   private LocalDate nextNotificationDate;
 
   @Schema(description = "사용자 ID", example = "1")

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
@@ -1,5 +1,6 @@
 package com.grimeet.grimeet.domain.userLog.repository;
 
+import com.grimeet.grimeet.domain.user.dto.UserStatus;
 import com.grimeet.grimeet.domain.userLog.entity.UserLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,10 +11,19 @@ import java.time.LocalDate;
 import java.util.List;
 
 @Repository
-public interface UserLogRepository extends JpaRepository<UserLog, Long> {
+public interface    UserLogRepository extends JpaRepository<UserLog, Long> {
     UserLog findUserLogByUserId(Long userId);
 
     List<UserLog> findByNextDormantCheckDateLessThanEqual(LocalDate date);
+
+    @Query("""
+    SELECT ul FROM UserLog ul
+    JOIN User u ON ul.userId = u.id
+    WHERE ul.nextDormantCheckDate <= :now
+    AND u.userStatus IN (:activeStatuses)
+    """)
+    List<UserLog> findCandidatesForDormantCheck(@Param("now") LocalDate now, @Param("activeStatuses") List<UserStatus> activeStatuses);
+
 
     @Query("SELECT u FROM UserLog u WHERE u.userId = :userId AND u.nextNotificationDate <= :now")
     UserLog findNextNotificationDateAfter(@Param("userId") Long id, @Param("now") LocalDate now);

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
@@ -16,6 +16,6 @@ public interface UserLogRepository extends JpaRepository<UserLog, Long> {
     @Query("SELECT u FROM UserLog u WHERE u.nextNotificationDate = :now")
     List<UserLog> findAllByNextNotificationDateEqual(@Param("now") LocalDate now);
 
-    @Query("SELECT u FROM UserLog u WHERE u.userId = :userId AND u.nextNotificationDate = :now")
-    UserLog findNextNotificationDateEqual(@Param("userId") Long id, @Param("now") LocalDate now);
+    @Query("SELECT u FROM UserLog u WHERE u.userId = :userId AND u.nextNotificationDate <= :now")
+    UserLog findNextNotificationDateAfter(@Param("userId") Long id, @Param("now") LocalDate now);
 }

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
@@ -2,9 +2,17 @@ package com.grimeet.grimeet.domain.userLog.repository;
 
 import com.grimeet.grimeet.domain.userLog.entity.UserLog;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface UserLogRepository extends JpaRepository<UserLog, Long> {
     UserLog findUserLogByUserId(Long userId);
+
+    @Query("SELECT u FROM UserLog u WHERE u.nextNotificationDate = :now")
+    List<UserLog> findAllByNextNotificationDateEqual(@Param("now") LocalDate now);
 }

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
@@ -4,7 +4,13 @@ import com.grimeet.grimeet.domain.userLog.entity.UserLog;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.util.List;
+
 @Repository
 public interface UserLogRepository extends JpaRepository<UserLog, Long> {
     UserLog findUserLogByUserId(Long userId);
+
+    List<UserLog> findByNextDormantCheckDateLessThanEqual(LocalDate date);
+
 }

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/repository/UserLogRepository.java
@@ -15,4 +15,7 @@ public interface UserLogRepository extends JpaRepository<UserLog, Long> {
 
     @Query("SELECT u FROM UserLog u WHERE u.nextNotificationDate = :now")
     List<UserLog> findAllByNextNotificationDateEqual(@Param("now") LocalDate now);
+
+    @Query("SELECT u FROM UserLog u WHERE u.userId = :userId AND u.nextNotificationDate = :now")
+    UserLog findNextNotificationDateEqual(@Param("userId") Long id, @Param("now") LocalDate now);
 }

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/scheduler/UserLogScheduler.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/scheduler/UserLogScheduler.java
@@ -1,0 +1,41 @@
+package com.grimeet.grimeet.domain.userLog.scheduler;
+
+import com.grimeet.grimeet.domain.userLog.entity.UserLog;
+import com.grimeet.grimeet.domain.userLog.repository.UserLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserLogScheduler {
+
+    private final UserLogRepository userLogRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    public void updateUserLogByDormantCheck() {
+        LocalDate now = LocalDate.now();
+        List<UserLog> userLogs = userLogRepository.findByNextDormantCheckDateLessThanEqual(now);
+
+        if (userLogs.isEmpty()) {
+            log.info("[스케줄러] 휴면 검사 대상 없음 (기준일: {})", now);
+            return;
+        }
+
+        log.info("[스케줄러] 휴면 검사 대상 {}명 발견", userLogs.size());
+
+        for (UserLog userLog : userLogs) {
+            userLog.updateNextDormantCheckDate(userLog.getNextDormantCheckDate().plusDays(365));
+            userLogRepository.save(userLog);
+        }
+
+        userLogRepository.saveAll(userLogs);
+        log.info("[스케줄러] 휴면 검사 주기 갱신 완료");
+    }
+
+}

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogFacade.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogFacade.java
@@ -1,0 +1,66 @@
+package com.grimeet.grimeet.domain.userLog.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * UserLogService의 메소드를 호출하여 UserLog를 생성하는 Facade 클래스
+ * @author jgone2
+ */
+@Component
+@RequiredArgsConstructor
+public class UserLogFacade {
+
+  private final UserLogService userLogService;
+
+  /**
+   * 유저의 비밀번호 변경 로그를 업데이트하는 메소드
+   * @param userId Long
+   */
+  public void updatePasswordLog(Long userId) {
+    userLogService.updateUserLogByPassword(userId);
+  }
+
+  /**
+   * 유저 로그인 시 로그를 업데이트하는 메소드
+   * @param userId Long
+   */
+  public void updateLoginLog(Long userId) {
+    userLogService.updateUserLogByLogin(userId);
+  }
+
+  /**
+   * 유저의 비밀번호 변경 권장 여부를 체크하는 메소드
+   * @param userId Long
+   */
+  public boolean checkNotificationRequired(Long userId) {
+    return userLogService.checkUserLogsForNotification(userId);
+  }
+
+  /**
+   * 유저의 휴면회원 전환 여부를 체크하는 메소드
+   * @param userId Long
+   */
+  public boolean checkDormantUserLog(Long userId) {
+    return userLogService.checkUserLogsForDormant(userId);
+  }
+
+  /**
+   * 유저의 로그를 생성하는 메소드
+   * @param userId Long
+   */
+  public void createUserLog(Long userId) {
+    userLogService.createUserLog(userId);
+  }
+
+  /**
+   * 유저의 휴면회원으로의 전환을 처리하는 메소드
+   * @param userIds List<Long>
+   */
+  public void convertUsersToDormant(List<Long> userIds) {
+    userLogService.convertUsersToDormant(userIds);
+  }
+}
+

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogService.java
@@ -9,6 +9,7 @@ public interface UserLogService {
   UserLogResponseDto findUserLogByUserId(Long userId);
   UserLogResponseDto findUserLogById(Long id);
   UserLogResponseDto updateUserLogByLogin(String userEmail);
+  boolean checkUserLogsForNotification(Long Id);
   UserLogResponseDto updateUserLogByPassword(String userEmail);
   List<UserLogResponseDto> findAllUserLogsForDormantCheck();
   List<UserLogResponseDto> findAllUserLogsForNotification();

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogService.java
@@ -12,5 +12,5 @@ public interface UserLogService {
   boolean checkUserLogsForNotification(Long Id);
   UserLogResponseDto updateUserLogByPassword(String userEmail);
   List<UserLogResponseDto> findAllUserLogsForDormantCheck();
-  List<UserLogResponseDto> findAllUserLogsForNotification();
+//  List<UserLogResponseDto> findAllUserLogsForNotification();
 }

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogService.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogService.java
@@ -5,12 +5,11 @@ import com.grimeet.grimeet.domain.userLog.dto.UserLogResponseDto;
 import java.util.List;
 
 public interface UserLogService {
-  UserLogResponseDto createUserLog(String userEmail);
-  UserLogResponseDto findUserLogByUserId(Long userId);
-  UserLogResponseDto findUserLogById(Long id);
-  UserLogResponseDto updateUserLogByLogin(String userEmail);
+  UserLogResponseDto createUserLog(Long userId);
+  UserLogResponseDto updateUserLogByLogin(Long userId);
   boolean checkUserLogsForNotification(Long Id);
-  UserLogResponseDto updateUserLogByPassword(String userEmail);
+  boolean checkUserLogsForDormant(Long Id);
+  UserLogResponseDto updateUserLogByPassword(Long userId);
+  void convertUsersToDormant(List<Long> userIds);
   List<UserLogResponseDto> findAllUserLogsForDormantCheck();
-//  List<UserLogResponseDto> findAllUserLogsForNotification();
 }

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
@@ -10,10 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
@@ -11,7 +11,9 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -86,9 +88,16 @@ public class UserLogServiceImpl implements UserLogService {
     return List.of();
   }
 
+  /**
+   * 다음 비밀번호 변경 알림 예정일이 지난 사용자 로그 조회
+   * @return List<UserLogResponseDto>
+   */
   @Override
   public List<UserLogResponseDto> findAllUserLogsForNotification() {
-    return List.of();
+    LocalDate now = LocalDate.now();
+    return userLogRepository.findAllByNextNotificationDateEqual(now).stream()
+            .map(UserLogResponseDto::new)
+            .collect(Collectors.toList());
   }
 
   /**

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
@@ -7,6 +7,7 @@ import com.grimeet.grimeet.domain.userLog.entity.UserLog;
 import com.grimeet.grimeet.domain.userLog.repository.UserLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cglib.core.Local;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -82,8 +83,16 @@ public class UserLogServiceImpl implements UserLogService {
 
   @Override
   public List<UserLogResponseDto> findAllUserLogsForDormantCheck() {
+    LocalDate now = LocalDate.now();
+    List<UserLog> userLogs = userLogRepository.findByNextDormantCheckDateLessThanEqual(now);
 
-    return List.of();
+    if (userLogs.isEmpty()) {
+      log.info("[휴면 사용자 조회] 대상 없음 (기준일자: {})", now);
+      return List.of();
+    }
+
+    log.info("[휴면 사용자 조회] 기준일자: {}, 대상자 수: {}", now, userLogs.size());
+    return userLogs.stream().map(UserLogResponseDto::new).toList();
   }
 
   @Override

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
@@ -92,12 +92,22 @@ public class UserLogServiceImpl implements UserLogService {
    * 다음 비밀번호 변경 알림 예정일이 지난 사용자 로그 조회
    * @return List<UserLogResponseDto>
    */
+//  @Override
+//  public List<UserLogResponseDto> findAllUserLogsForNotification() {
+//    LocalDate now = LocalDate.now();
+//    return userLogRepository.findAllByNextNotificationDateEqual(now).stream()
+//            .map(UserLogResponseDto::new)
+//            .collect(Collectors.toList());
+//  }
+
+  /**
+   * 다음 비밀번호 변경 알림 예정일이 지났는지 확인
+   * @return
+   */
   @Override
-  public List<UserLogResponseDto> findAllUserLogsForNotification() {
+  public boolean checkUserLogsForNotification(Long userId) {
     LocalDate now = LocalDate.now();
-    return userLogRepository.findAllByNextNotificationDateEqual(now).stream()
-            .map(UserLogResponseDto::new)
-            .collect(Collectors.toList());
+    return userLogRepository.findNextNotificationDateEqual(userId, now) != null;
   }
 
   /**

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
@@ -104,7 +104,7 @@ public class UserLogServiceImpl implements UserLogService {
   @Override
   public boolean checkUserLogsForNotification(Long userId) {
     LocalDate now = LocalDate.now();
-    return userLogRepository.findNextNotificationDateEqual(userId, now) != null;
+    return userLogRepository.findNextNotificationDateAfter(userId, now) != null;
   }
 
   /**

--- a/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
+++ b/src/main/java/com/grimeet/grimeet/domain/userLog/service/UserLogServiceImpl.java
@@ -28,7 +28,7 @@ public class UserLogServiceImpl implements UserLogService {
    */
   @Override
   public UserLogResponseDto createUserLog(String userEmail) {
-    UserResponseDto findUserResponseDto = userService.findUserByUserEmail(userEmail);
+    UserResponseDto findUserResponseDto = userService.findUserByEmail(userEmail);
     LocalDate now = LocalDate.now();
     UserLog userLog = UserLog.builder()
             .lastLoginAt(now)
@@ -58,7 +58,7 @@ public class UserLogServiceImpl implements UserLogService {
    */
   @Override
   public UserLogResponseDto updateUserLogByLogin(String userEmail) {
-    UserResponseDto findUserResponseDto = userService.findUserByUserEmail(userEmail);
+    UserResponseDto findUserResponseDto = userService.findUserByEmail(userEmail);
     UserLog userLog = userLogRepository.findUserLogByUserId(findUserResponseDto.getId());
 
     LocalDate now = LocalDate.now();
@@ -70,7 +70,7 @@ public class UserLogServiceImpl implements UserLogService {
 
   @Override
   public UserLogResponseDto updateUserLogByPassword(String userEmail) {
-    UserResponseDto findUserResponseDto = userService.findUserByUserEmail(userEmail);
+    UserResponseDto findUserResponseDto = userService.findUserByEmail(userEmail);
     UserLog userLog = userLogRepository.findUserLogByUserId(findUserResponseDto.getId());
 
     LocalDate now = LocalDate.now();

--- a/src/test/java/com/grimeet/grimeet/GrimeetApplicationTests.java
+++ b/src/test/java/com/grimeet/grimeet/GrimeetApplicationTests.java
@@ -1,13 +1,13 @@
-//package com.grimeet.grimeet;
-//
-//import org.junit.jupiter.api.Test;
-//import org.springframework.boot.test.context.SpringBootTest;
-//
-//@SpringBootTest
-//class GrimeetApplicationTests {
-//
-//	@Test
-//	void contextLoads() {
-//	}
-//
-//}
+package com.grimeet.grimeet;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class GrimeetApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/src/test/java/com/grimeet/grimeet/common/batch/user/UserLogSchedulerTest.java
+++ b/src/test/java/com/grimeet/grimeet/common/batch/user/UserLogSchedulerTest.java
@@ -1,0 +1,65 @@
+package com.grimeet.grimeet.common.batch.user;
+
+import com.grimeet.grimeet.domain.user.entity.User;
+import com.grimeet.grimeet.domain.userLog.entity.UserLog;
+import com.grimeet.grimeet.domain.userLog.repository.UserLogRepository;
+import com.grimeet.grimeet.domain.user.repository.UserRepository;
+import com.grimeet.grimeet.common.batch.user.UserLogScheduler;
+import com.grimeet.grimeet.domain.user.dto.UserStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+public class UserLogSchedulerTest {
+
+    @Autowired
+    private UserLogScheduler scheduler;
+
+    @Autowired
+    private UserLogRepository userLogRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = userRepository.save(User.builder()
+                .name("스케줄러유저")
+                .email("scheduler@example.com")
+                .password("encoded")
+                .nickname("스케줄러")
+                .phoneNumber("010-0000-0000")
+                .userStatus(UserStatus.NORMAL)
+                .build());
+
+        // 휴면 검사 날짜가 오늘인 경우만 대상이 됨
+        userLogRepository.save(UserLog.builder()
+                .userId(user.getId())
+                .nextDormantCheckDate(LocalDate.now()) // 오늘!
+                .build());
+    }
+
+    @Test
+    void 휴면_대상_유저를_정상적으로_처리한다() {
+        scheduler.updateUserLogByDormantCheck();
+
+        User updated = userRepository.findById(user.getId()).orElseThrow();
+        assertThat(updated.getUserStatus()).isEqualTo(UserStatus.DORMANT);
+    }
+
+}
+

--- a/src/test/java/com/grimeet/grimeet/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/grimeet/grimeet/domain/user/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import com.grimeet.grimeet.domain.user.dto.UserStatus;
 import com.grimeet.grimeet.domain.user.entity.User;
 import com.grimeet.grimeet.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -51,6 +52,7 @@ class UserServiceTest {
                 .build());
     }
 
+    @DisplayName("정상_상태의_유저를_휴면으로_전환한다")
     @Test
     void 정상_상태의_유저를_휴면으로_전환한다() {
         List<Long> ids = List.of(user1.getId(), user2.getId());
@@ -63,6 +65,7 @@ class UserServiceTest {
         }
     }
 
+    @DisplayName("유저가_없는_경우에도_예외없이_동작한다")
     @Test
     void 유저가_없는_경우에도_예외없이_동작한다() {
         // given

--- a/src/test/java/com/grimeet/grimeet/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/grimeet/grimeet/domain/user/service/UserServiceTest.java
@@ -1,0 +1,78 @@
+package com.grimeet.grimeet.domain.user.service;
+
+import com.grimeet.grimeet.domain.user.dto.UserStatus;
+import com.grimeet.grimeet.domain.user.entity.User;
+import com.grimeet.grimeet.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user1;
+    private User user2;
+
+    @BeforeEach
+    void setUp() {
+        user1 = userRepository.save(User.builder()
+                .name("홍길동")
+                .email("test1@example.com")
+                .password("encodedPassword1")
+                .nickname("길동이")
+                .phoneNumber("010-1111-1111")
+                .userStatus(UserStatus.NORMAL)
+                .build());
+
+        user2 = userRepository.save(User.builder()
+                .name("김철수")
+                .email("test2@example.com")
+                .password("encodedPassword2")
+                .nickname("철수")
+                .phoneNumber("010-2222-2222")
+                .userStatus(UserStatus.SOCIAL)
+                .build());
+    }
+
+    @Test
+    void 정상_상태의_유저를_휴면으로_전환한다() {
+        List<Long> ids = List.of(user1.getId(), user2.getId());
+
+        userService.updateUserStatusDormantBatch(ids);
+
+        List<User> updated = userRepository.findByIdInAndUserStatusIn(ids, List.of(UserStatus.NORMAL, UserStatus.SOCIAL));
+        for (User user : updated) {
+            assertEquals(UserStatus.DORMANT, user.getUserStatus());
+        }
+    }
+
+    @Test
+    void 유저가_없는_경우에도_예외없이_동작한다() {
+        // given
+        List<Long> emptyIds = new ArrayList<>();
+
+        // when
+        assertDoesNotThrow(() -> userService.updateUserStatusDormantBatch(emptyIds));
+
+        // then
+        // 별도 검증 없음, 예외 없이 끝났으면 성공
+    }
+
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:mysql://127.0.0.1:3307/grim?serverTimezone=UTC&characterEncoding=UTF-8
+    username: ${GRIM_MYSQL_USER}
+    password: ${GRIM_MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    profiles:
+      active: test


### PR DESCRIPTION
## 🖍️ 이슈번호
<!-- 이슈 번호를 작성해 주세요. ex) #1 -->

- close #36 

## 🧑‍💻 작업사항

- [x] 팔로우/팔로잉 기능을 POST요청 하나로 서비스 로직 내부에서 분기하여 Toggle형식으로 구현 -> 로그인 한 상태에서만 동작
- [x] 팔로워/팔로잉 목록 조회 구현 -> 로그인 없이 해당 유저의 id값으로 조회
- [x] 팔로잉 여부 조회 -> 로그인한 상태에서 내가 팔로우/팔로잉 버튼을 토글 형식으로 해당 기능을 구현했기 때문에 여부를 판단하기 위해 구현

## 📸 스크린샷

<!-- 필요한 경우 스크린샷을 첨부해주세요 -->

## 💡 참고사항

<!-- 리뷰어가 참고해야 할 사항 혹은 논의사항이 있다면 작성해주세요 -->
개발 중에 팔로워/팔로잉 목록을 조회하는 중 `직렬화 이슈`가 있었습니다. 유저 정보를 Lazy로딩하면서 발생한 이슈였는데
반환 타입을 새로운 DTO(UserSummaryResponseDto)를 생성 후 적용하여 해결했습니다.

테스트는 포스트맨 테스트를 우선 완료하였습니다.

## 🙏 기타사항
- 이전 PR인 토큰 관련 로직 개선 및 순환의존 이슈 해결 PR의 브랜치에서 새 브랜치를 생성하여 파일 변환이 많은데,
- Follow폴더 내의 로직만 확인 해주시면 됩니다. + common/exception에서 예외처리 추가 까지.

## ✅ PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
